### PR TITLE
fix(menu): 多 View 批量权限按 component 分段对齐 code 后缀

### DIFF
--- a/system/views/admin/menu.py
+++ b/system/views/admin/menu.py
@@ -24,6 +24,11 @@ from system.signal_handler import clean_cache_handler
 from system.utils.menu import get_view_permissions
 
 
+def _view_class_code_suffix(view_import_path: str) -> str:
+    """从 View 导入路径解析用于权限 code 的后缀（去掉 ViewSet/APIView）。"""
+    return view_import_path.split(".")[-1].replace("ViewSet", "").replace("APIView", "").strip()
+
+
 class MenuFilter(BaseFilterSet):
     name = filters.CharFilter(field_name='name', lookup_expr='icontains')
     component = filters.CharFilter(field_name='component', lookup_expr='icontains')
@@ -123,12 +128,17 @@ class MenuViewSet(BaseModelSet, RankAction, ImportExportDataAction, ChoicesActio
         skip_existing = request.data.get('skip_existing')
         if isinstance(views, list) and len(views) > 0:
             instance = self.get_object()
+            component_parts = [p.strip() for p in str(component).split("|")] if component else []
+            parts_len = len(component_parts)
+            is_single_view = len(views) == 1
 
-            for view in views:
-                code_suffix = view.split(".")[-1].replace('ViewSet', ' ').replace('APIView', ' ')
-                if len(views) == 1:
-                    if component:
-                        code_suffix = component
+            for idx, view in enumerate(views):
+                if is_single_view:
+                    code_suffix = str(component).strip() if component else _view_class_code_suffix(view)
+                else:
+                    code_suffix = _view_class_code_suffix(view)
+                    if idx < parts_len and component_parts[idx]:
+                        code_suffix = component_parts[idx]
                 self._save_permissions(instance, get_view_permissions(view, code_suffix), skip_existing)
 
             # 保存数据，触发刷新缓存信号


### PR DESCRIPTION
- 多 views 时解析 'Name1 | Name2' 与 views 顺序一一对应
- 单 view 仍使用整段 component；抽取 _view_class_code_suffix 避免尾部异常空格

<img width="501" height="237" alt="image" src="https://github.com/user-attachments/assets/d770c3a4-7206-4aed-8659-24c121245001" />

菜单可能依赖多个视图，在『自动批量添加权限』中勾选多个视图时，权限标识后缀会通过“ | ”来拼接。
但之前代码只处理了len(views)==1的情况，未处理len(views)>1情况
<img width="831" height="294" alt="image" src="https://github.com/user-attachments/assets/d65a0a87-5918-40c2-a7a0-0938033f318a" />
