### PR TITLE
.661283291792508:7abf0f0fd0128d0d5e6b2bd679b77680_69f04ab775f86b32ef82ae99.69f0514f91adcad3d326c62c.69f0514e105280027073b112:Trae CN.T(2026/4/28 14:18:55)

### DIFF
--- a/announcement/__init__.py
+++ b/announcement/__init__.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AnnouncementConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'announcement'
+    verbose_name = '系统公告'

--- a/announcement/admin.py
+++ b/announcement/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/announcement/apps.py
+++ b/announcement/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AnnouncementConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'announcement'
+    verbose_name = '系统公告'

--- a/announcement/config.py
+++ b/announcement/config.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+from django.urls import path, include
+
+URLPATTERNS = [
+    path('api/announcement/', include('announcement.urls')),
+]
+
+PERMISSION_WHITE_REURL = {
+    "^/api/announcement/user$": ['GET'],
+    "^/api/announcement/user/.*$": ['GET'],
+}

--- a/announcement/models.py
+++ b/announcement/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from common.core.models import DbAuditModel
+
+
+class Announcement(DbAuditModel):
+    class StatusChoices(models.IntegerChoices):
+        DRAFT = 0, _("草稿")
+        PUBLISHED = 1, _("已发布")
+
+    title = models.CharField(max_length=200, verbose_name=_("标题"))
+    content = models.TextField(verbose_name=_("内容"))
+    is_top = models.BooleanField(default=False, verbose_name=_("是否置顶"))
+    status = models.SmallIntegerField(choices=StatusChoices, default=StatusChoices.DRAFT, verbose_name=_("状态"))
+    publish_time = models.DateTimeField(null=True, blank=True, verbose_name=_("发布时间"))
+
+    class Meta:
+        verbose_name = _("系统公告")
+        verbose_name_plural = verbose_name
+        ordering = ['-is_top', '-publish_time', '-created_time']
+
+    def __str__(self):
+        return self.title

--- a/announcement/models.py
+++ b/announcement/models.py
@@ -12,6 +12,7 @@ class Announcement(DbAuditModel):
     title = models.CharField(max_length=200, verbose_name=_("标题"))
     content = models.TextField(verbose_name=_("内容"))
     is_top = models.BooleanField(default=False, verbose_name=_("是否置顶"))
+    is_published = models.BooleanField(default=False, verbose_name=_("是否发布"))
     status = models.SmallIntegerField(choices=StatusChoices, default=StatusChoices.DRAFT, verbose_name=_("状态"))
     publish_time = models.DateTimeField(null=True, blank=True, verbose_name=_("发布时间"))
 

--- a/announcement/serializers/__init__.py
+++ b/announcement/serializers/__init__.py
@@ -1,0 +1,3 @@
+from .announcement import AnnouncementSerializer, AnnouncementUserSerializer
+
+__all__ = ['AnnouncementSerializer', 'AnnouncementUserSerializer']

--- a/announcement/serializers/announcement.py
+++ b/announcement/serializers/announcement.py
@@ -8,11 +8,11 @@ class AnnouncementSerializer(BaseModelSerializer):
     class Meta:
         model = models.Announcement
         fields = [
-            'pk', 'title', 'content', 'is_top', 'status', 'publish_time',
+            'pk', 'title', 'content', 'is_top', 'is_published', 'status', 'publish_time',
             'creator', 'modifier', 'dept_belong', 'created_time', 'updated_time', 'description'
         ]
         table_fields = [
-            'pk', 'title', 'is_top', 'status', 'publish_time', 'creator', 'created_time'
+            'pk', 'title', 'is_top', 'is_published', 'status', 'publish_time', 'creator', 'created_time'
         ]
         read_only_fields = ['pk', 'creator', 'modifier', 'dept_belong', 'created_time', 'updated_time']
         extra_kwargs = {

--- a/announcement/serializers/announcement.py
+++ b/announcement/serializers/announcement.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers
+
+from common.core.serializers import BaseModelSerializer
+from announcement import models
+
+
+class AnnouncementSerializer(BaseModelSerializer):
+    class Meta:
+        model = models.Announcement
+        fields = [
+            'pk', 'title', 'content', 'is_top', 'status', 'publish_time',
+            'creator', 'modifier', 'dept_belong', 'created_time', 'updated_time', 'description'
+        ]
+        table_fields = [
+            'pk', 'title', 'is_top', 'status', 'publish_time', 'creator', 'created_time'
+        ]
+        read_only_fields = ['pk', 'creator', 'modifier', 'dept_belong', 'created_time', 'updated_time']
+        extra_kwargs = {
+            'creator': {
+                'attrs': ['pk', 'username'], 'format': "{username}({pk})",
+            },
+            'modifier': {
+                'attrs': ['pk', 'username'], 'format': "{username}({pk})",
+            },
+        }
+
+
+class AnnouncementUserSerializer(BaseModelSerializer):
+    creator_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Announcement
+        fields = [
+            'pk', 'title', 'content', 'is_top', 'publish_time', 'creator_name', 'created_time'
+        ]
+        read_only_fields = fields
+
+    def get_creator_name(self, obj):
+        if obj.creator:
+            return obj.creator.username
+        return None

--- a/announcement/tests.py
+++ b/announcement/tests.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/announcement/urls.py
+++ b/announcement/urls.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+from rest_framework.routers import SimpleRouter
+
+from announcement.views.admin import AnnouncementAdminViewSet
+from announcement.views.user import AnnouncementUserViewSet
+
+app_name = 'announcement'
+
+router = SimpleRouter(False)
+
+router.register('admin', AnnouncementAdminViewSet, basename='announcement-admin')
+router.register('user', AnnouncementUserViewSet, basename='announcement-user')
+
+urlpatterns = [
+]
+urlpatterns += router.urls

--- a/announcement/views/__init__.py
+++ b/announcement/views/__init__.py
@@ -1,0 +1,4 @@
+from .admin import AnnouncementAdminViewSet
+from .user import AnnouncementUserViewSet
+
+__all__ = ['AnnouncementAdminViewSet', 'AnnouncementUserViewSet']

--- a/announcement/views/admin.py
+++ b/announcement/views/admin.py
@@ -1,0 +1,62 @@
+from django.utils import timezone
+from django_filters import rest_framework as filters
+from rest_framework.decorators import action
+
+from common.core.filter import BaseFilterSet
+from common.core.modelset import BaseModelSet, ImportExportDataAction
+from common.core.pagination import DynamicPageNumber
+from common.core.response import ApiResponse
+from announcement.models import Announcement
+from announcement.serializers import AnnouncementSerializer
+
+
+class AnnouncementAdminFilter(BaseFilterSet):
+    title = filters.CharFilter(field_name='title', lookup_expr='icontains')
+    is_top = filters.BooleanFilter(field_name='is_top')
+    status = filters.NumberFilter(field_name='status')
+
+    class Meta:
+        model = Announcement
+        fields = ['title', 'is_top', 'status', 'created_time', 'publish_time']
+
+
+class AnnouncementAdminViewSet(BaseModelSet, ImportExportDataAction):
+    """系统公告管理"""
+    queryset = Announcement.objects.all()
+    serializer_class = AnnouncementSerializer
+    ordering_fields = ['created_time', 'publish_time', 'is_top']
+    filterset_class = AnnouncementAdminFilter
+    pagination_class = DynamicPageNumber(1000)
+
+    def perform_create(self, serializer):
+        instance = serializer.save(creator=self.request.user, dept_belong=self.request.user.dept)
+        if instance.status == Announcement.StatusChoices.PUBLISHED and not instance.publish_time:
+            instance.publish_time = timezone.now()
+            instance.save(update_fields=['publish_time'])
+
+    def perform_update(self, serializer):
+        instance = serializer.save(modifier=self.request.user)
+        if instance.status == Announcement.StatusChoices.PUBLISHED and not instance.publish_time:
+            instance.publish_time = timezone.now()
+            instance.save(update_fields=['publish_time'])
+
+    @action(methods=['post'], detail=True)
+    def publish(self, request, *args, **kwargs):
+        """发布公告"""
+        instance = self.get_object()
+        if instance.status != Announcement.StatusChoices.PUBLISHED:
+            instance.status = Announcement.StatusChoices.PUBLISHED
+            instance.publish_time = timezone.now()
+            instance.modifier = request.user
+            instance.save(update_fields=['status', 'publish_time', 'modifier'])
+        return ApiResponse(detail=_("发布成功"))
+
+    @action(methods=['post'], detail=True)
+    def unpublish(self, request, *args, **kwargs):
+        """取消发布公告"""
+        instance = self.get_object()
+        if instance.status == Announcement.StatusChoices.PUBLISHED:
+            instance.status = Announcement.StatusChoices.DRAFT
+            instance.modifier = request.user
+            instance.save(update_fields=['status', 'modifier'])
+        return ApiResponse(detail=_("取消发布成功"))

--- a/announcement/views/admin.py
+++ b/announcement/views/admin.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from rest_framework.decorators import action
 
@@ -13,11 +14,12 @@ from announcement.serializers import AnnouncementSerializer
 class AnnouncementAdminFilter(BaseFilterSet):
     title = filters.CharFilter(field_name='title', lookup_expr='icontains')
     is_top = filters.BooleanFilter(field_name='is_top')
+    is_published = filters.BooleanFilter(field_name='is_published')
     status = filters.NumberFilter(field_name='status')
 
     class Meta:
         model = Announcement
-        fields = ['title', 'is_top', 'status', 'created_time', 'publish_time']
+        fields = ['title', 'is_top', 'is_published', 'status', 'created_time', 'publish_time']
 
 
 class AnnouncementAdminViewSet(BaseModelSet, ImportExportDataAction):
@@ -30,13 +32,13 @@ class AnnouncementAdminViewSet(BaseModelSet, ImportExportDataAction):
 
     def perform_create(self, serializer):
         instance = serializer.save(creator=self.request.user, dept_belong=self.request.user.dept)
-        if instance.status == Announcement.StatusChoices.PUBLISHED and not instance.publish_time:
+        if instance.is_published and not instance.publish_time:
             instance.publish_time = timezone.now()
             instance.save(update_fields=['publish_time'])
 
     def perform_update(self, serializer):
         instance = serializer.save(modifier=self.request.user)
-        if instance.status == Announcement.StatusChoices.PUBLISHED and not instance.publish_time:
+        if instance.is_published and not instance.publish_time:
             instance.publish_time = timezone.now()
             instance.save(update_fields=['publish_time'])
 
@@ -44,19 +46,21 @@ class AnnouncementAdminViewSet(BaseModelSet, ImportExportDataAction):
     def publish(self, request, *args, **kwargs):
         """发布公告"""
         instance = self.get_object()
-        if instance.status != Announcement.StatusChoices.PUBLISHED:
+        if not instance.is_published:
+            instance.is_published = True
             instance.status = Announcement.StatusChoices.PUBLISHED
             instance.publish_time = timezone.now()
             instance.modifier = request.user
-            instance.save(update_fields=['status', 'publish_time', 'modifier'])
+            instance.save(update_fields=['is_published', 'status', 'publish_time', 'modifier'])
         return ApiResponse(detail=_("发布成功"))
 
     @action(methods=['post'], detail=True)
     def unpublish(self, request, *args, **kwargs):
-        """取消发布公告"""
+        """下架公告"""
         instance = self.get_object()
-        if instance.status == Announcement.StatusChoices.PUBLISHED:
+        if instance.is_published:
+            instance.is_published = False
             instance.status = Announcement.StatusChoices.DRAFT
             instance.modifier = request.user
-            instance.save(update_fields=['status', 'modifier'])
-        return ApiResponse(detail=_("取消发布成功"))
+            instance.save(update_fields=['is_published', 'status', 'modifier'])
+        return ApiResponse(detail=_("下架成功"))

--- a/announcement/views/user.py
+++ b/announcement/views/user.py
@@ -1,0 +1,28 @@
+from django_filters import rest_framework as filters
+
+from common.core.filter import BaseFilterSet
+from common.core.modelset import OnlyListModelSet, DetailAction
+from common.core.pagination import DynamicPageNumber
+from announcement.models import Announcement
+from announcement.serializers import AnnouncementUserSerializer
+
+
+class AnnouncementUserFilter(BaseFilterSet):
+    title = filters.CharFilter(field_name='title', lookup_expr='icontains')
+
+    class Meta:
+        model = Announcement
+        fields = ['title', 'is_top', 'publish_time']
+
+
+class AnnouncementUserViewSet(OnlyListModelSet, DetailAction):
+    """用户公告查看"""
+    serializer_class = AnnouncementUserSerializer
+    ordering_fields = ['is_top', 'publish_time']
+    filterset_class = AnnouncementUserFilter
+    pagination_class = DynamicPageNumber(1000)
+
+    def get_queryset(self):
+        return Announcement.objects.filter(
+            status=Announcement.StatusChoices.PUBLISHED
+        ).order_by('-is_top', '-publish_time')

--- a/announcement/views/user.py
+++ b/announcement/views/user.py
@@ -12,17 +12,17 @@ class AnnouncementUserFilter(BaseFilterSet):
 
     class Meta:
         model = Announcement
-        fields = ['title', 'is_top', 'publish_time']
+        fields = ['title', 'is_top', 'publish_time', 'created_time']
 
 
 class AnnouncementUserViewSet(OnlyListModelSet, DetailAction):
     """用户公告查看"""
     serializer_class = AnnouncementUserSerializer
-    ordering_fields = ['is_top', 'publish_time']
+    ordering_fields = ['is_top', 'publish_time', 'created_time']
     filterset_class = AnnouncementUserFilter
     pagination_class = DynamicPageNumber(1000)
 
     def get_queryset(self):
         return Announcement.objects.filter(
-            status=Announcement.StatusChoices.PUBLISHED
-        ).order_by('-is_top', '-publish_time')
+            is_published=True
+        ).order_by('-is_top', '-created_time')

--- a/frontend-example/index.html
+++ b/frontend-example/index.html
@@ -1,0 +1,22 @@
+{
+  "name": "announcement-frontend-example",
+  "version": "1.0.0",
+  "description": "系统公告前端示例代码 - Vue3 + Element Plus",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "axios": "^1.6.0",
+    "element-plus": "^2.4.0",
+    "@element-plus/icons-vue": "^2.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/frontend-example/package.json
+++ b/frontend-example/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "announcement-frontend-example",
+  "version": "1.0.0",
+  "description": "系统公告前端示例代码 - Vue3 + Element Plus",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "axios": "^1.6.0",
+    "element-plus": "^2.4.0",
+    "@element-plus/icons-vue": "^2.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/frontend-example/src/App.vue
+++ b/frontend-example/src/App.vue
@@ -1,0 +1,60 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import * as ElementPlusIconsVue from '@element-plus/icons-vue'
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/',
+    redirect: '/admin/announcement'
+  },
+  {
+    path: '/admin/announcement',
+    name: 'AnnouncementList',
+    component: () => import('./views/admin/AnnouncementList.vue'),
+    meta: { title: '公告管理' }
+  },
+  {
+    path: '/admin/announcement/create',
+    name: 'AnnouncementCreate',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '新建公告' }
+  },
+  {
+    path: '/admin/announcement/edit/:id',
+    name: 'AnnouncementEdit',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '编辑公告' }
+  },
+  {
+    path: '/user/announcement',
+    name: 'UserAnnouncementList',
+    component: () => import('./views/user/AnnouncementList.vue'),
+    meta: { title: '公告列表' }
+  },
+  {
+    path: '/user/announcement/:id',
+    name: 'UserAnnouncementDetail',
+    component: () => import('./views/user/AnnouncementDetail.vue'),
+    meta: { title: '公告详情' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+const app = createApp(App)
+
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
+  app.component(key, component)
+}
+
+app.use(router)
+app.use(ElementPlus, { locale: zhCn })
+
+app.mount('#app')

--- a/frontend-example/src/api/announcement.ts
+++ b/frontend-example/src/api/announcement.ts
@@ -1,0 +1,60 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import * as ElementPlusIconsVue from '@element-plus/icons-vue'
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/',
+    redirect: '/admin/announcement'
+  },
+  {
+    path: '/admin/announcement',
+    name: 'AnnouncementList',
+    component: () => import('./views/admin/AnnouncementList.vue'),
+    meta: { title: '公告管理' }
+  },
+  {
+    path: '/admin/announcement/create',
+    name: 'AnnouncementCreate',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '新建公告' }
+  },
+  {
+    path: '/admin/announcement/edit/:id',
+    name: 'AnnouncementEdit',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '编辑公告' }
+  },
+  {
+    path: '/user/announcement',
+    name: 'UserAnnouncementList',
+    component: () => import('./views/user/AnnouncementList.vue'),
+    meta: { title: '公告列表' }
+  },
+  {
+    path: '/user/announcement/:id',
+    name: 'UserAnnouncementDetail',
+    component: () => import('./views/user/AnnouncementDetail.vue'),
+    meta: { title: '公告详情' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+const app = createApp(App)
+
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
+  app.component(key, component)
+}
+
+app.use(router)
+app.use(ElementPlus, { locale: zhCn })
+
+app.mount('#app')

--- a/frontend-example/src/api/request.ts
+++ b/frontend-example/src/api/request.ts
@@ -1,0 +1,60 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import * as ElementPlusIconsVue from '@element-plus/icons-vue'
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/',
+    redirect: '/admin/announcement'
+  },
+  {
+    path: '/admin/announcement',
+    name: 'AnnouncementList',
+    component: () => import('./views/admin/AnnouncementList.vue'),
+    meta: { title: '公告管理' }
+  },
+  {
+    path: '/admin/announcement/create',
+    name: 'AnnouncementCreate',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '新建公告' }
+  },
+  {
+    path: '/admin/announcement/edit/:id',
+    name: 'AnnouncementEdit',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '编辑公告' }
+  },
+  {
+    path: '/user/announcement',
+    name: 'UserAnnouncementList',
+    component: () => import('./views/user/AnnouncementList.vue'),
+    meta: { title: '公告列表' }
+  },
+  {
+    path: '/user/announcement/:id',
+    name: 'UserAnnouncementDetail',
+    component: () => import('./views/user/AnnouncementDetail.vue'),
+    meta: { title: '公告详情' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+const app = createApp(App)
+
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
+  app.component(key, component)
+}
+
+app.use(router)
+app.use(ElementPlus, { locale: zhCn })
+
+app.mount('#app')

--- a/frontend-example/src/main.ts
+++ b/frontend-example/src/main.ts
@@ -1,0 +1,60 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import zhCn from 'element-plus/es/locale/lang/zh-cn'
+import * as ElementPlusIconsVue from '@element-plus/icons-vue'
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/',
+    redirect: '/admin/announcement'
+  },
+  {
+    path: '/admin/announcement',
+    name: 'AnnouncementList',
+    component: () => import('./views/admin/AnnouncementList.vue'),
+    meta: { title: '公告管理' }
+  },
+  {
+    path: '/admin/announcement/create',
+    name: 'AnnouncementCreate',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '新建公告' }
+  },
+  {
+    path: '/admin/announcement/edit/:id',
+    name: 'AnnouncementEdit',
+    component: () => import('./views/admin/AnnouncementForm.vue'),
+    meta: { title: '编辑公告' }
+  },
+  {
+    path: '/user/announcement',
+    name: 'UserAnnouncementList',
+    component: () => import('./views/user/AnnouncementList.vue'),
+    meta: { title: '公告列表' }
+  },
+  {
+    path: '/user/announcement/:id',
+    name: 'UserAnnouncementDetail',
+    component: () => import('./views/user/AnnouncementDetail.vue'),
+    meta: { title: '公告详情' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+const app = createApp(App)
+
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
+  app.component(key, component)
+}
+
+app.use(router)
+app.use(ElementPlus, { locale: zhCn })
+
+app.mount('#app')

--- a/frontend-example/src/views/admin/AnnouncementForm.vue
+++ b/frontend-example/src/views/admin/AnnouncementForm.vue
@@ -1,0 +1,340 @@
+<template>
+  <div class="announcement-container">
+    <el-card class="search-card">
+      <el-form :inline="true" :model="searchForm" class="search-form">
+        <el-form-item label="标题">
+          <el-input v-model="searchForm.title" placeholder="请输入标题" clearable @keyup.enter="handleSearch" />
+        </el-form-item>
+        <el-form-item label="是否置顶">
+          <el-select v-model="searchForm.is_top" placeholder="请选择" clearable>
+            <el-option label="是" :value="true" />
+            <el-option label="否" :value="false" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="发布状态">
+          <el-select v-model="searchForm.is_published" placeholder="请选择" clearable>
+            <el-option label="已发布" :value="true" />
+            <el-option label="未发布" :value="false" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSearch">
+            <el-icon><Search /></el-icon>
+            搜索
+          </el-button>
+          <el-button @click="handleReset">
+            <el-icon><Refresh /></el-icon>
+            重置
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <el-card class="table-card">
+      <template #header>
+        <div class="card-header">
+          <span>公告列表</span>
+          <el-button type="primary" @click="handleCreate">
+            <el-icon><Plus /></el-icon>
+            新建公告
+          </el-button>
+        </div>
+      </template>
+
+      <el-table :data="tableData" v-loading="loading" stripe style="width: 100%">
+        <el-table-column prop="pk" label="ID" width="100" />
+        <el-table-column prop="title" label="标题" min-width="200" show-overflow-tooltip />
+        <el-table-column prop="is_top" label="是否置顶" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.is_top ? 'success' : 'info'">
+              {{ row.is_top ? '置顶' : '普通' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="is_published" label="发布状态" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.is_published ? 'success' : 'warning'">
+              {{ row.is_published ? '已发布' : '未发布' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="creator" label="发布人" width="120">
+          <template #default="{ row }">
+            {{ row.creator?.username || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="publish_time" label="发布时间" width="180">
+          <template #default="{ row }">
+            {{ row.publish_time ? formatDate(row.publish_time) : '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="created_time" label="创建时间" width="180">
+          <template #default="{ row }">
+            {{ formatDate(row.created_time) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="280" fixed="right">
+          <template #default="{ row }">
+            <el-button type="primary" link @click="handleEdit(row)">
+              <el-icon><Edit /></el-icon>
+              编辑
+            </el-button>
+            <el-button type="primary" link @click="handleView(row)">
+              <el-icon><View /></el-icon>
+              详情
+            </el-button>
+            <el-button v-if="!row.is_published" type="success" link @click="handlePublish(row)">
+              <el-icon><Promotion /></el-icon>
+              发布
+            </el-button>
+            <el-button v-else type="warning" link @click="handleUnpublish(row)">
+              <el-icon><Download /></el-icon>
+              下架
+            </el-button>
+            <el-button type="danger" link @click="handleDelete(row)">
+              <el-icon><Delete /></el-icon>
+              删除
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <div class="pagination-container">
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.pageSize"
+          :page-sizes="[10, 20, 50, 100]"
+          layout="total, sizes, prev, pager, next, jumper"
+          :total="pagination.total"
+          @size-change="handleSizeChange"
+          @current-change="handleCurrentChange"
+        />
+      </div>
+    </el-card>
+
+    <el-dialog v-model="detailVisible" title="公告详情" width="700px">
+      <el-descriptions :column="2" border>
+        <el-descriptions-item label="标题" :span="2">
+          {{ detailData.title }}
+        </el-descriptions-item>
+        <el-descriptions-item label="是否置顶">
+          <el-tag :type="detailData.is_top ? 'success' : 'info'">
+            {{ detailData.is_top ? '置顶' : '普通' }}
+          </el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="发布状态">
+          <el-tag :type="detailData.is_published ? 'success' : 'warning'">
+            {{ detailData.is_published ? '已发布' : '未发布' }}
+          </el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="发布人">
+          {{ detailData.creator?.username || '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item label="发布时间">
+          {{ detailData.publish_time ? formatDate(detailData.publish_time) : '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item label="创建时间">
+          {{ formatDate(detailData.created_time) }}
+        </el-descriptions-item>
+        <el-descriptions-item label="更新时间">
+          {{ formatDate(detailData.updated_time) }}
+        </el-descriptions-item>
+        <el-descriptions-item label="内容" :span="2">
+          <div class="detail-content">{{ detailData.content }}</div>
+        </el-descriptions-item>
+      </el-descriptions>
+    </el-dialog>
+
+    <el-dialog v-model="deleteVisible" title="确认删除" width="400px">
+      <span>确定要删除公告「{{ deleteData.title }}」吗？此操作不可恢复。</span>
+      <template #footer>
+        <el-button @click="deleteVisible = false">取消</el-button>
+        <el-button type="danger" @click="confirmDelete">确认删除</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  getAnnouncementList,
+  getAnnouncementDetail,
+  deleteAnnouncement,
+  publishAnnouncement,
+  unpublishAnnouncement,
+  type AnnouncementItem
+} from '@/api/announcement'
+
+const router = useRouter()
+
+const loading = ref(false)
+const tableData = ref<AnnouncementItem[]>([])
+const detailVisible = ref(false)
+const deleteVisible = ref(false)
+const detailData = ref<AnnouncementItem>({} as AnnouncementItem)
+const deleteData = ref<AnnouncementItem>({} as AnnouncementItem)
+
+const searchForm = reactive({
+  title: '',
+  is_top: undefined as boolean | undefined,
+  is_published: undefined as boolean | undefined
+})
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 10,
+  total: 0
+})
+
+const formatDate = (date: string) => {
+  if (!date) return '-'
+  return new Date(date).toLocaleString('zh-CN')
+}
+
+const fetchData = async () => {
+  loading.value = true
+  try {
+    const params: Record<string, any> = {
+      page: pagination.page,
+      page_size: pagination.pageSize
+    }
+    if (searchForm.title) params.title = searchForm.title
+    if (searchForm.is_top !== undefined) params.is_top = searchForm.is_top
+    if (searchForm.is_published !== undefined) params.is_published = searchForm.is_published
+
+    const res = await getAnnouncementList(params)
+    tableData.value = res.data.results || res.data || []
+    pagination.total = res.data.count || tableData.value.length
+  } catch (error) {
+    console.error('获取公告列表失败:', error)
+    ElMessage.error('获取公告列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleSearch = () => {
+  pagination.page = 1
+  fetchData()
+}
+
+const handleReset = () => {
+  searchForm.title = ''
+  searchForm.is_top = undefined
+  searchForm.is_published = undefined
+  handleSearch()
+}
+
+const handleSizeChange = (size: number) => {
+  pagination.pageSize = size
+  fetchData()
+}
+
+const handleCurrentChange = (page: number) => {
+  pagination.page = page
+  fetchData()
+}
+
+const handleCreate = () => {
+  router.push('/admin/announcement/create')
+}
+
+const handleEdit = (row: AnnouncementItem) => {
+  router.push(`/admin/announcement/edit/${row.pk}`)
+}
+
+const handleView = async (row: AnnouncementItem) => {
+  try {
+    const res = await getAnnouncementDetail(row.pk)
+    detailData.value = res.data
+    detailVisible.value = true
+  } catch (error) {
+    ElMessage.error('获取公告详情失败')
+  }
+}
+
+const handlePublish = async (row: AnnouncementItem) => {
+  try {
+    await ElMessageBox.confirm(`确定要发布公告「${row.title}」吗？`, '确认发布', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+      type: 'warning'
+    })
+    await publishAnnouncement(row.pk)
+    ElMessage.success('发布成功')
+    fetchData()
+  } catch (error: any) {
+    if (error !== 'cancel') {
+      ElMessage.error('发布失败')
+    }
+  }
+}
+
+const handleUnpublish = async (row: AnnouncementItem) => {
+  try {
+    await ElMessageBox.confirm(`确定要下架公告「${row.title}」吗？`, '确认下架', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+      type: 'warning'
+    })
+    await unpublishAnnouncement(row.pk)
+    ElMessage.success('下架成功')
+    fetchData()
+  } catch (error: any) {
+    if (error !== 'cancel') {
+      ElMessage.error('下架失败')
+    }
+  }
+}
+
+const handleDelete = (row: AnnouncementItem) => {
+  deleteData.value = row
+  deleteVisible.value = true
+}
+
+const confirmDelete = async () => {
+  try {
+    await deleteAnnouncement(deleteData.value.pk)
+    ElMessage.success('删除成功')
+    deleteVisible.value = false
+    fetchData()
+  } catch (error) {
+    ElMessage.error('删除失败')
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
+</script>
+
+<style scoped>
+.announcement-container {
+  padding: 20px;
+}
+
+.search-card {
+  margin-bottom: 20px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pagination-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.detail-content {
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.8;
+}
+</style>

--- a/frontend-example/src/views/admin/AnnouncementList.vue
+++ b/frontend-example/src/views/admin/AnnouncementList.vue
@@ -1,0 +1,340 @@
+<template>
+  <div class="announcement-container">
+    <el-card class="search-card">
+      <el-form :inline="true" :model="searchForm" class="search-form">
+        <el-form-item label="标题">
+          <el-input v-model="searchForm.title" placeholder="请输入标题" clearable @keyup.enter="handleSearch" />
+        </el-form-item>
+        <el-form-item label="是否置顶">
+          <el-select v-model="searchForm.is_top" placeholder="请选择" clearable>
+            <el-option label="是" :value="true" />
+            <el-option label="否" :value="false" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="发布状态">
+          <el-select v-model="searchForm.is_published" placeholder="请选择" clearable>
+            <el-option label="已发布" :value="true" />
+            <el-option label="未发布" :value="false" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSearch">
+            <el-icon><Search /></el-icon>
+            搜索
+          </el-button>
+          <el-button @click="handleReset">
+            <el-icon><Refresh /></el-icon>
+            重置
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <el-card class="table-card">
+      <template #header>
+        <div class="card-header">
+          <span>公告列表</span>
+          <el-button type="primary" @click="handleCreate">
+            <el-icon><Plus /></el-icon>
+            新建公告
+          </el-button>
+        </div>
+      </template>
+
+      <el-table :data="tableData" v-loading="loading" stripe style="width: 100%">
+        <el-table-column prop="pk" label="ID" width="100" />
+        <el-table-column prop="title" label="标题" min-width="200" show-overflow-tooltip />
+        <el-table-column prop="is_top" label="是否置顶" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.is_top ? 'success' : 'info'">
+              {{ row.is_top ? '置顶' : '普通' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="is_published" label="发布状态" width="100">
+          <template #default="{ row }">
+            <el-tag :type="row.is_published ? 'success' : 'warning'">
+              {{ row.is_published ? '已发布' : '未发布' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="creator" label="发布人" width="120">
+          <template #default="{ row }">
+            {{ row.creator?.username || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="publish_time" label="发布时间" width="180">
+          <template #default="{ row }">
+            {{ row.publish_time ? formatDate(row.publish_time) : '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="created_time" label="创建时间" width="180">
+          <template #default="{ row }">
+            {{ formatDate(row.created_time) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="280" fixed="right">
+          <template #default="{ row }">
+            <el-button type="primary" link @click="handleEdit(row)">
+              <el-icon><Edit /></el-icon>
+              编辑
+            </el-button>
+            <el-button type="primary" link @click="handleView(row)">
+              <el-icon><View /></el-icon>
+              详情
+            </el-button>
+            <el-button v-if="!row.is_published" type="success" link @click="handlePublish(row)">
+              <el-icon><Promotion /></el-icon>
+              发布
+            </el-button>
+            <el-button v-else type="warning" link @click="handleUnpublish(row)">
+              <el-icon><Download /></el-icon>
+              下架
+            </el-button>
+            <el-button type="danger" link @click="handleDelete(row)">
+              <el-icon><Delete /></el-icon>
+              删除
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <div class="pagination-container">
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.pageSize"
+          :page-sizes="[10, 20, 50, 100]"
+          layout="total, sizes, prev, pager, next, jumper"
+          :total="pagination.total"
+          @size-change="handleSizeChange"
+          @current-change="handleCurrentChange"
+        />
+      </div>
+    </el-card>
+
+    <el-dialog v-model="detailVisible" title="公告详情" width="700px">
+      <el-descriptions :column="2" border>
+        <el-descriptions-item label="标题" :span="2">
+          {{ detailData.title }}
+        </el-descriptions-item>
+        <el-descriptions-item label="是否置顶">
+          <el-tag :type="detailData.is_top ? 'success' : 'info'">
+            {{ detailData.is_top ? '置顶' : '普通' }}
+          </el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="发布状态">
+          <el-tag :type="detailData.is_published ? 'success' : 'warning'">
+            {{ detailData.is_published ? '已发布' : '未发布' }}
+          </el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="发布人">
+          {{ detailData.creator?.username || '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item label="发布时间">
+          {{ detailData.publish_time ? formatDate(detailData.publish_time) : '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item label="创建时间">
+          {{ formatDate(detailData.created_time) }}
+        </el-descriptions-item>
+        <el-descriptions-item label="更新时间">
+          {{ formatDate(detailData.updated_time) }}
+        </el-descriptions-item>
+        <el-descriptions-item label="内容" :span="2">
+          <div class="detail-content">{{ detailData.content }}</div>
+        </el-descriptions-item>
+      </el-descriptions>
+    </el-dialog>
+
+    <el-dialog v-model="deleteVisible" title="确认删除" width="400px">
+      <span>确定要删除公告「{{ deleteData.title }}」吗？此操作不可恢复。</span>
+      <template #footer>
+        <el-button @click="deleteVisible = false">取消</el-button>
+        <el-button type="danger" @click="confirmDelete">确认删除</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  getAnnouncementList,
+  getAnnouncementDetail,
+  deleteAnnouncement,
+  publishAnnouncement,
+  unpublishAnnouncement,
+  type AnnouncementItem
+} from '@/api/announcement'
+
+const router = useRouter()
+
+const loading = ref(false)
+const tableData = ref<AnnouncementItem[]>([])
+const detailVisible = ref(false)
+const deleteVisible = ref(false)
+const detailData = ref<AnnouncementItem>({} as AnnouncementItem)
+const deleteData = ref<AnnouncementItem>({} as AnnouncementItem)
+
+const searchForm = reactive({
+  title: '',
+  is_top: undefined as boolean | undefined,
+  is_published: undefined as boolean | undefined
+})
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 10,
+  total: 0
+})
+
+const formatDate = (date: string) => {
+  if (!date) return '-'
+  return new Date(date).toLocaleString('zh-CN')
+}
+
+const fetchData = async () => {
+  loading.value = true
+  try {
+    const params: Record<string, any> = {
+      page: pagination.page,
+      page_size: pagination.pageSize
+    }
+    if (searchForm.title) params.title = searchForm.title
+    if (searchForm.is_top !== undefined) params.is_top = searchForm.is_top
+    if (searchForm.is_published !== undefined) params.is_published = searchForm.is_published
+
+    const res = await getAnnouncementList(params)
+    tableData.value = res.data.results || res.data || []
+    pagination.total = res.data.count || tableData.value.length
+  } catch (error) {
+    console.error('获取公告列表失败:', error)
+    ElMessage.error('获取公告列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleSearch = () => {
+  pagination.page = 1
+  fetchData()
+}
+
+const handleReset = () => {
+  searchForm.title = ''
+  searchForm.is_top = undefined
+  searchForm.is_published = undefined
+  handleSearch()
+}
+
+const handleSizeChange = (size: number) => {
+  pagination.pageSize = size
+  fetchData()
+}
+
+const handleCurrentChange = (page: number) => {
+  pagination.page = page
+  fetchData()
+}
+
+const handleCreate = () => {
+  router.push('/admin/announcement/create')
+}
+
+const handleEdit = (row: AnnouncementItem) => {
+  router.push(`/admin/announcement/edit/${row.pk}`)
+}
+
+const handleView = async (row: AnnouncementItem) => {
+  try {
+    const res = await getAnnouncementDetail(row.pk)
+    detailData.value = res.data
+    detailVisible.value = true
+  } catch (error) {
+    ElMessage.error('获取公告详情失败')
+  }
+}
+
+const handlePublish = async (row: AnnouncementItem) => {
+  try {
+    await ElMessageBox.confirm(`确定要发布公告「${row.title}」吗？`, '确认发布', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+      type: 'warning'
+    })
+    await publishAnnouncement(row.pk)
+    ElMessage.success('发布成功')
+    fetchData()
+  } catch (error: any) {
+    if (error !== 'cancel') {
+      ElMessage.error('发布失败')
+    }
+  }
+}
+
+const handleUnpublish = async (row: AnnouncementItem) => {
+  try {
+    await ElMessageBox.confirm(`确定要下架公告「${row.title}」吗？`, '确认下架', {
+      confirmButtonText: '确定',
+      cancelButtonText: '取消',
+      type: 'warning'
+    })
+    await unpublishAnnouncement(row.pk)
+    ElMessage.success('下架成功')
+    fetchData()
+  } catch (error: any) {
+    if (error !== 'cancel') {
+      ElMessage.error('下架失败')
+    }
+  }
+}
+
+const handleDelete = (row: AnnouncementItem) => {
+  deleteData.value = row
+  deleteVisible.value = true
+}
+
+const confirmDelete = async () => {
+  try {
+    await deleteAnnouncement(deleteData.value.pk)
+    ElMessage.success('删除成功')
+    deleteVisible.value = false
+    fetchData()
+  } catch (error) {
+    ElMessage.error('删除失败')
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
+</script>
+
+<style scoped>
+.announcement-container {
+  padding: 20px;
+}
+
+.search-card {
+  margin-bottom: 20px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pagination-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.detail-content {
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.8;
+}
+</style>

--- a/frontend-example/src/views/user/AnnouncementDetail.vue
+++ b/frontend-example/src/views/user/AnnouncementDetail.vue
@@ -1,0 +1,359 @@
+<template>
+  <div class="announcement-user-container">
+    <el-card class="header-card">
+      <template #header>
+        <div class="card-header">
+          <span><el-icon><Bell /></el-icon> 系统公告</span>
+        </div>
+      </template>
+      <el-form :inline="true" :model="searchForm" class="search-form">
+        <el-form-item>
+          <el-input
+            v-model="searchForm.title"
+            placeholder="请输入标题搜索"
+            prefix-icon="Search"
+            clearable
+            @keyup.enter="handleSearch"
+            style="width: 300px"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSearch">
+            <el-icon><Search /></el-icon>
+            搜索
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <div class="announcement-list" v-loading="loading">
+      <div
+        v-for="item in listData"
+        :key="item.pk"
+        class="announcement-item"
+        @click="handleViewDetail(item)"
+      >
+        <div class="item-header">
+          <div class="item-title">
+            <el-tag v-if="item.is_top" type="danger" effect="dark" class="top-tag">
+              置顶
+            </el-tag>
+            <span class="title-text">{{ item.title }}</span>
+          </div>
+          <div class="item-meta">
+            <span class="meta-item">
+              <el-icon><User /></el-icon>
+              {{ item.creator_name || '系统' }}
+            </span>
+            <span class="meta-item">
+              <el-icon><Clock /></el-icon>
+              {{ formatDate(item.publish_time || item.created_time) }}
+            </span>
+          </div>
+        </div>
+        <div class="item-content">
+          {{ item.content.length > 150 ? item.content.substring(0, 150) + '...' : item.content }}
+        </div>
+        <div class="item-footer">
+          <span class="view-more">查看详情 <el-icon><Right /></el-icon></span>
+        </div>
+      </div>
+
+      <el-empty v-if="listData.length === 0 && !loading" description="暂无公告" />
+    </div>
+
+    <div class="pagination-container" v-if="listData.length > 0">
+      <el-pagination
+        v-model:current-page="pagination.page"
+        v-model:page-size="pagination.pageSize"
+        :page-sizes="[10, 20, 50]"
+        layout="total, prev, pager, next"
+        :total="pagination.total"
+        @current-change="handleCurrentChange"
+        @size-change="handleSizeChange"
+      />
+    </div>
+
+    <el-dialog
+      v-model="detailVisible"
+      title="公告详情"
+      width="700px"
+      :close-on-click-modal="false"
+    >
+      <div class="detail-content" v-if="detailData">
+        <div class="detail-header">
+          <h2 class="detail-title">
+            <el-tag v-if="detailData.is_top" type="danger" effect="dark" class="top-tag">
+              置顶
+            </el-tag>
+            {{ detailData.title }}
+          </h2>
+          <div class="detail-meta">
+            <span>
+              <el-icon><User /></el-icon>
+              发布人：{{ detailData.creator_name || '系统' }}
+            </span>
+            <span>
+              <el-icon><Clock /></el-icon>
+              发布时间：{{ formatDate(detailData.publish_time || detailData.created_time) }}
+            </span>
+          </div>
+        </div>
+        <el-divider />
+        <div class="detail-body">
+          {{ detailData.content }}
+        </div>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import {
+  getUserAnnouncementList,
+  getUserAnnouncementDetail,
+  type UserAnnouncementItem
+} from '@/api/announcement'
+
+const router = useRouter()
+
+const loading = ref(false)
+const listData = ref<UserAnnouncementItem[]>([])
+const detailVisible = ref(false)
+const detailData = ref<UserAnnouncementItem | null>(null)
+
+const searchForm = reactive({
+  title: ''
+})
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 10,
+  total: 0
+})
+
+const formatDate = (date: string) => {
+  if (!date) return '-'
+  return new Date(date).toLocaleString('zh-CN')
+}
+
+const fetchData = async () => {
+  loading.value = true
+  try {
+    const params: Record<string, any> = {
+      page: pagination.page,
+      page_size: pagination.pageSize
+    }
+    if (searchForm.title) {
+      params.title = searchForm.title
+    }
+
+    const res = await getUserAnnouncementList(params)
+    listData.value = res.data.results || res.data || []
+    pagination.total = res.data.count || listData.value.length
+  } catch (error) {
+    console.error('获取公告列表失败:', error)
+    ElMessage.error('获取公告列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleSearch = () => {
+  pagination.page = 1
+  fetchData()
+}
+
+const handleCurrentChange = (page: number) => {
+  pagination.page = page
+  fetchData()
+}
+
+const handleSizeChange = (size: number) => {
+  pagination.pageSize = size
+  pagination.page = 1
+  fetchData()
+}
+
+const handleViewDetail = async (item: UserAnnouncementItem) => {
+  try {
+    const res = await getUserAnnouncementDetail(item.pk)
+    detailData.value = res.data
+    detailVisible.value = true
+  } catch (error) {
+    ElMessage.error('获取公告详情失败')
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
+</script>
+
+<style scoped>
+.announcement-user-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.header-card {
+  margin-bottom: 20px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.card-header .el-icon {
+  margin-right: 8px;
+  color: #409eff;
+}
+
+.search-form {
+  margin-top: 10px;
+}
+
+.announcement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.announcement-item {
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 1px solid #ebeef5;
+}
+
+.announcement-item:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.item-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.top-tag {
+  flex-shrink: 0;
+}
+
+.title-text {
+  font-size: 16px;
+  font-weight: 600;
+  color: #303133;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-meta {
+  display: flex;
+  gap: 20px;
+  flex-shrink: 0;
+  margin-left: 20px;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #909399;
+  font-size: 13px;
+}
+
+.item-content {
+  color: #606266;
+  font-size: 14px;
+  line-height: 1.8;
+  margin-bottom: 12px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.item-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.view-more {
+  color: #409eff;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pagination-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.detail-content {
+  padding: 10px 0;
+}
+
+.detail-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.detail-title {
+  font-size: 22px;
+  font-weight: bold;
+  color: #303133;
+  margin: 0 0 16px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.detail-meta {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  color: #909399;
+  font-size: 14px;
+}
+
+.detail-meta span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.detail-body {
+  color: #303133;
+  font-size: 15px;
+  line-height: 2;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/frontend-example/src/views/user/AnnouncementList.vue
+++ b/frontend-example/src/views/user/AnnouncementList.vue
@@ -1,0 +1,359 @@
+<template>
+  <div class="announcement-user-container">
+    <el-card class="header-card">
+      <template #header>
+        <div class="card-header">
+          <span><el-icon><Bell /></el-icon> 系统公告</span>
+        </div>
+      </template>
+      <el-form :inline="true" :model="searchForm" class="search-form">
+        <el-form-item>
+          <el-input
+            v-model="searchForm.title"
+            placeholder="请输入标题搜索"
+            prefix-icon="Search"
+            clearable
+            @keyup.enter="handleSearch"
+            style="width: 300px"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSearch">
+            <el-icon><Search /></el-icon>
+            搜索
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <div class="announcement-list" v-loading="loading">
+      <div
+        v-for="item in listData"
+        :key="item.pk"
+        class="announcement-item"
+        @click="handleViewDetail(item)"
+      >
+        <div class="item-header">
+          <div class="item-title">
+            <el-tag v-if="item.is_top" type="danger" effect="dark" class="top-tag">
+              置顶
+            </el-tag>
+            <span class="title-text">{{ item.title }}</span>
+          </div>
+          <div class="item-meta">
+            <span class="meta-item">
+              <el-icon><User /></el-icon>
+              {{ item.creator_name || '系统' }}
+            </span>
+            <span class="meta-item">
+              <el-icon><Clock /></el-icon>
+              {{ formatDate(item.publish_time || item.created_time) }}
+            </span>
+          </div>
+        </div>
+        <div class="item-content">
+          {{ item.content.length > 150 ? item.content.substring(0, 150) + '...' : item.content }}
+        </div>
+        <div class="item-footer">
+          <span class="view-more">查看详情 <el-icon><Right /></el-icon></span>
+        </div>
+      </div>
+
+      <el-empty v-if="listData.length === 0 && !loading" description="暂无公告" />
+    </div>
+
+    <div class="pagination-container" v-if="listData.length > 0">
+      <el-pagination
+        v-model:current-page="pagination.page"
+        v-model:page-size="pagination.pageSize"
+        :page-sizes="[10, 20, 50]"
+        layout="total, prev, pager, next"
+        :total="pagination.total"
+        @current-change="handleCurrentChange"
+        @size-change="handleSizeChange"
+      />
+    </div>
+
+    <el-dialog
+      v-model="detailVisible"
+      title="公告详情"
+      width="700px"
+      :close-on-click-modal="false"
+    >
+      <div class="detail-content" v-if="detailData">
+        <div class="detail-header">
+          <h2 class="detail-title">
+            <el-tag v-if="detailData.is_top" type="danger" effect="dark" class="top-tag">
+              置顶
+            </el-tag>
+            {{ detailData.title }}
+          </h2>
+          <div class="detail-meta">
+            <span>
+              <el-icon><User /></el-icon>
+              发布人：{{ detailData.creator_name || '系统' }}
+            </span>
+            <span>
+              <el-icon><Clock /></el-icon>
+              发布时间：{{ formatDate(detailData.publish_time || detailData.created_time) }}
+            </span>
+          </div>
+        </div>
+        <el-divider />
+        <div class="detail-body">
+          {{ detailData.content }}
+        </div>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import {
+  getUserAnnouncementList,
+  getUserAnnouncementDetail,
+  type UserAnnouncementItem
+} from '@/api/announcement'
+
+const router = useRouter()
+
+const loading = ref(false)
+const listData = ref<UserAnnouncementItem[]>([])
+const detailVisible = ref(false)
+const detailData = ref<UserAnnouncementItem | null>(null)
+
+const searchForm = reactive({
+  title: ''
+})
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 10,
+  total: 0
+})
+
+const formatDate = (date: string) => {
+  if (!date) return '-'
+  return new Date(date).toLocaleString('zh-CN')
+}
+
+const fetchData = async () => {
+  loading.value = true
+  try {
+    const params: Record<string, any> = {
+      page: pagination.page,
+      page_size: pagination.pageSize
+    }
+    if (searchForm.title) {
+      params.title = searchForm.title
+    }
+
+    const res = await getUserAnnouncementList(params)
+    listData.value = res.data.results || res.data || []
+    pagination.total = res.data.count || listData.value.length
+  } catch (error) {
+    console.error('获取公告列表失败:', error)
+    ElMessage.error('获取公告列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleSearch = () => {
+  pagination.page = 1
+  fetchData()
+}
+
+const handleCurrentChange = (page: number) => {
+  pagination.page = page
+  fetchData()
+}
+
+const handleSizeChange = (size: number) => {
+  pagination.pageSize = size
+  pagination.page = 1
+  fetchData()
+}
+
+const handleViewDetail = async (item: UserAnnouncementItem) => {
+  try {
+    const res = await getUserAnnouncementDetail(item.pk)
+    detailData.value = res.data
+    detailVisible.value = true
+  } catch (error) {
+    ElMessage.error('获取公告详情失败')
+  }
+}
+
+onMounted(() => {
+  fetchData()
+})
+</script>
+
+<style scoped>
+.announcement-user-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.header-card {
+  margin-bottom: 20px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.card-header .el-icon {
+  margin-right: 8px;
+  color: #409eff;
+}
+
+.search-form {
+  margin-top: 10px;
+}
+
+.announcement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.announcement-item {
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 1px solid #ebeef5;
+}
+
+.announcement-item:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.item-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.top-tag {
+  flex-shrink: 0;
+}
+
+.title-text {
+  font-size: 16px;
+  font-weight: 600;
+  color: #303133;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-meta {
+  display: flex;
+  gap: 20px;
+  flex-shrink: 0;
+  margin-left: 20px;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #909399;
+  font-size: 13px;
+}
+
+.item-content {
+  color: #606266;
+  font-size: 14px;
+  line-height: 1.8;
+  margin-bottom: 12px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.item-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.view-more {
+  color: #409eff;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pagination-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.detail-content {
+  padding: 10px 0;
+}
+
+.detail-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.detail-title {
+  font-size: 22px;
+  font-weight: bold;
+  color: #303133;
+  margin: 0 0 16px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.detail-meta {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  color: #909399;
+  font-size: 14px;
+}
+
+.detail-meta span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.detail-body {
+  color: #303133;
+  font-size: 15px;
+  line-height: 2;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/frontend-example/tsconfig.json
+++ b/frontend-example/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "name": "announcement-frontend-example",
+  "version": "1.0.0",
+  "description": "系统公告前端示例代码 - Vue3 + Element Plus",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "axios": "^1.6.0",
+    "element-plus": "^2.4.0",
+    "@element-plus/icons-vue": "^2.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/frontend-example/vite.config.ts
+++ b/frontend-example/vite.config.ts
@@ -1,0 +1,22 @@
+{
+  "name": "announcement-frontend-example",
+  "version": "1.0.0",
+  "description": "系统公告前端示例代码 - Vue3 + Element Plus",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "axios": "^1.6.0",
+    "element-plus": "^2.4.0",
+    "@element-plus/icons-vue": "^2.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "typescript": "^5.3.0"
+  }
+}


### PR DESCRIPTION
feat(公告): 添加公告发布状态字段并优化前后端功能

refactor(公告): 重构公告状态管理逻辑，使用is_published字段替代status判断

feat(前端): 新增公告管理前端示例项目，包含Vue3+Element Plus实现

fix(公告): 修复公告列表排序和过滤条件问题